### PR TITLE
MAVLink Client Enhancements (TCP/multi-MAV/system ID parameter)

### DIFF
--- a/src/agents/mavlink_agent.hpp
+++ b/src/agents/mavlink_agent.hpp
@@ -70,7 +70,8 @@ public:
         desc.add_options()
             ("client_ip,i", boost::program_options::value<std::string>(), "IP to stream the MAVLink UDP data to. Default 127.0.0.1")
             ("port,p", boost::program_options::value<unsigned short int>(), "UDP Port. Default 14551.")
-            ("system_ids", boost::program_options::value<std::vector<uint8_t>>()->multitoken(), "MAVLink destination system id(s) - should be in the same order as the streaming IDs. Default 42.")
+            // TODO: This is actually a uint8_t, but that seems to be interpreted as an ASCII character -> gives the wrong number (even unsigned char?)
+            ("system_ids", boost::program_options::value<std::vector<unsigned short int>>()->multitoken(), "MAVLink destination system id(s) - should be in the same order as the streaming IDs. Default 42.")
             ("autopilot,a", boost::program_options::value<std::string>(), "One of [arducopter, arduplane, px4]")
         ;
     }
@@ -97,7 +98,7 @@ public:
         
         // System IDs, should match the number of streaming IDs
         if (vm.count("system_ids")) {
-            this->_mav_system_ids = vm["system_ids"].as<std::vector<uint8_t>>();
+            this->_mav_system_ids = vm["system_ids"].as<std::vector<unsigned short int>>();
         } else {
             std::cout << "No MAVLink system ids given, using default of 42" << std::endl;
             this->_mav_system_ids = {42};
@@ -111,7 +112,7 @@ public:
             // Log the streaming IDs and their corresponding MAVLink system IDs
             std::cout << "MAVLink system IDs mappings: " << std::endl;
             for (size_t i = 0; i < this->streaming_ids.size(); ++i) {
-                std::cout << " - Streaming ID " << this->streaming_ids[i] << " -> MAVLink System ID " << static_cast<int>(this->_mav_system_ids[i]) << std::endl;
+                std::cout << " - Streaming ID " << this->streaming_ids[i] << " -> MAVLink System ID " << this->_mav_system_ids[i] << std::endl;
             }
         }
 
@@ -417,7 +418,7 @@ public:
 private:
     unsigned short int _port;
     std::string _client_ip;
-    std::vector<uint8_t> _mav_system_ids;
+    std::vector<unsigned short int> _mav_system_ids;
 
     int socket_fd;
     struct sockaddr_in src_addr = {};

--- a/src/agents/mavlink_agent.hpp
+++ b/src/agents/mavlink_agent.hpp
@@ -70,7 +70,7 @@ public:
         desc.add_options()
             ("client_ip,i", boost::program_options::value<std::string>(), "IP to stream the MAVLink UDP data to. Default 127.0.0.1")
             ("port,p", boost::program_options::value<unsigned short int>(), "UDP Port. Default 14551.")
-            //("system_id,sid", boost::program_options::value<std::vector<unsigned int>>()->multitoken(), "MAVLink destination system id.")
+            ("system_id", boost::program_options::value<unsigned short int>(), "MAVLink destination system id. Default 42.")
             ("autopilot,a", boost::program_options::value<std::string>(), "One of [arducopter, arduplane, px4]")
         ;
     }
@@ -93,6 +93,15 @@ public:
         } else {
             std::cout << "No MAVLink UDP port given. Assume 14551" << std::endl;
             this->_port = 14551;
+        }
+
+        if (vm.count("system_id")) {
+            unsigned short int val = vm["system_id"].as<unsigned short int>();
+            std::cout << "Streaming to MAVLINK system ID " << val << std::endl;
+            this->_mav_system_id = val;
+        } else {
+            std::cout << "No MAVLink System ID given. Assume 42" << std::endl;
+            this->_mav_system_id = 42;
         }
 
         if (this->streaming_ids.size() > 1) {
@@ -222,7 +231,6 @@ public:
 
         mavlink_message_t message;
 
-        uint8_t system_id = 42;
         struct timeval tv;
         uint64_t timestamp_us;
         gettimeofday(&tv, NULL);
@@ -237,7 +245,7 @@ public:
         //printf("%ld,%f,%f,%f\n", timestamp_us, pose.x, pose.y, pose.z);
 
         mavlink_msg_vision_position_estimate_pack(
-                system_id,
+                _mav_system_id,
                 MAV_COMP_ID_PERIPHERAL,
                 &message,
                 timestamp_us,
@@ -267,7 +275,6 @@ public:
 
         mavlink_message_t message;
 
-        uint8_t system_id = 42;
         struct timeval tv;
         uint64_t timestamp_us;
         gettimeofday(&tv, NULL);
@@ -281,7 +288,7 @@ public:
         //printf("%ld,%f,%f,%f\n", timestamp_us, pose.x, pose.y, pose.z);
 
         mavlink_msg_att_pos_mocap_pack(
-                system_id,
+                _mav_system_id,
                 MAV_COMP_ID_PERIPHERAL,
                 &message,
                 timestamp_us,
@@ -308,14 +315,13 @@ public:
 
         mavlink_message_t message;
 
-        uint8_t system_id = 42;
         struct timeval tv;
         uint64_t timestamp_us;
         gettimeofday(&tv, NULL);
         timestamp_us = (long long)tv.tv_sec * 1000000LL + (long long)tv.tv_usec;
 
         mavlink_msg_gps_input_pack(
-            system_id,
+            _mav_system_id,
             MAV_COMP_ID_PERIPHERAL,
             &message,
             timestamp_us,
@@ -405,6 +411,7 @@ public:
 private:
     unsigned short int _port;
     std::string _client_ip;
+    unsigned short int _mav_system_id;
 
     int socket_fd;
     struct sockaddr_in src_addr = {};


### PR DESCRIPTION
This PR adds the following to the MAVLINK optitrack client:
- Support for a TCP MAVLINK router target (`--tcp` flag)
- Support for specifying a custom MAVLink System ID (`--system_ids`, in line with the streaming IDs flag)
- Support for relaying multiple rigid bodies to the MAVLink server (specify a streaming ID, nose and system ID for each MAV; order of arguments must be consistent/is used for matching)

Our testing includes:
- The test client + MAVLink-router + multiple px4 MAVs (though the MAVLINK router setup used will route all clients to all destinations - we had to reduce the publishing frequency to avoid saturation of our serial connection). Both MAVs receive the correct visual odometry data.
- Optitrack + a single px4 MAV with a non-default system ID, visual odometry/local position works correctly.
- TCP uplink over a local wired ethernet connection to a secondary device acting as a MAVLink router.

Furthermore, during testing, we noticed the existing UDP client always binds "locally", rather than running `sendto` directly if the IP is non-local. Could check for `0.0.0.0`/`127.0.0.1`, add a flag, or something else. Likely out of the scope of this PR, but this would help make the bahavior between our TCP client and the existing UDP client/server more consistent.